### PR TITLE
Add mod_auth_mellon support to puppetlabs-apache

### DIFF
--- a/manifests/mod/authnz_mellon.pp
+++ b/manifests/mod/authnz_mellon.pp
@@ -1,0 +1,19 @@
+class apache::mod::authnz_mellon (
+  $verifyServerCert = true,
+) {
+  include '::apache::mod::mellon'
+  ::apache::mod { 'authnz_mellon': }
+
+  validate_bool($verifyServerCert)
+
+  # Template uses:
+  # - $verifyServerCert
+  file { 'authnz_mellon.conf':
+    ensure  => file,
+    path    => "${::apache::mod_dir}/authnz_mellon.conf",
+    content => template('apache/mod/authnz_mellon.conf.erb'),
+    require => Exec["mkdir ${::apache::mod_dir}"],
+    before  => File[$::apache::mod_dir],
+    notify  => Service['httpd'],
+  }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -67,31 +67,32 @@ class apache::params inherits ::apache::version {
     $suphp_configpath     = undef
     # NOTE: The module for Shibboleth is not available to RH/CentOS without an additional repository. http://wiki.aaf.edu.au/tech-info/sp-install-guide
     $mod_packages         = {
-      'auth_kerb'   => 'mod_auth_kerb',
-      'authnz_ldap' => $::apache::version::distrelease ? {
+      'auth_kerb'     => 'mod_auth_kerb',
+      'authnz_ldap'   => $::apache::version::distrelease ? {
         '7'     => 'mod_ldap',
         default => 'mod_authz_ldap',
-      },
-      'fastcgi'     => 'mod_fastcgi',
-      'fcgid'       => 'mod_fcgid',
-      'pagespeed'   => 'mod-pagespeed-stable',
-      'passenger'   => 'mod_passenger',
-      'perl'        => 'mod_perl',
-      'php5'        => $::apache::version::distrelease ? {
+       },
+      'authnz_mellon' => 'mod_auth_mellon',
+      'fastcgi'       => 'mod_fastcgi',
+      'fcgid'         => 'mod_fcgid',
+      'pagespeed'     => 'mod-pagespeed-stable',
+      'passenger'     => 'mod_passenger',
+      'perl'          => 'mod_perl',
+      'php5'          => $::apache::version::distrelease ? {
         '5'     => 'php53',
         default => 'php',
       },
-      'proxy_html'  => 'mod_proxy_html',
-      'python'      => 'mod_python',
-      'security'    => 'mod_security',
-      'shibboleth'  => 'shibboleth',
-      'ssl'         => 'mod_ssl',
-      'wsgi'        => 'mod_wsgi',
-      'dav_svn'     => 'mod_dav_svn',
-      'suphp'       => 'mod_suphp',
-      'xsendfile'   => 'mod_xsendfile',
-      'nss'         => 'mod_nss',
-      'shib2'       => 'shibboleth',
+      'proxy_html'    => 'mod_proxy_html',
+      'python'        => 'mod_python',
+      'security'      => 'mod_security',
+      'shibboleth'    => 'shibboleth',
+      'ssl'           => 'mod_ssl',
+      'wsgi'          => 'mod_wsgi',
+      'dav_svn'       => 'mod_dav_svn',
+      'suphp'         => 'mod_suphp',
+      'xsendfile'     => 'mod_xsendfile',
+      'nss'           => 'mod_nss',
+      'shib2'         => 'shibboleth',
     }
     $mod_libs             = {
       'php5' => 'libphp5.so',

--- a/spec/classes/mod/authnz_mellon_spec.rb
+++ b/spec/classes/mod/authnz_mellon_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+describe 'apache::mod::authnz_mellon', :type => :class do
+  let :pre_condition do
+    'include apache'
+  end
+
+  context "on a Debian OS" do
+    let :facts do
+      {
+        :lsbdistcodename        => 'squeeze',
+        :osfamily               => 'Debian',
+        :operatingsystemrelease => '6',
+        :concat_basedir         => '/dne',
+        :id                     => 'root',
+        :kernel                 => 'Linux',
+        :operatingsystem        => 'Debian',
+        :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      }
+    end
+    it { is_expected.to contain_class("apache::params") }
+    it { is_expected.to contain_class("apache::mod::mellon") }
+    it { is_expected.to contain_apache__mod('authnz_mellon') }
+
+    context 'default verifyServerCert' do
+      it { is_expected.to contain_file('authnz_mellon.conf').with_content(/^MELLONVerifyServerCert On$/) }
+    end
+
+    context 'verifyServerCert = false' do
+      let(:params) { { :verifyServerCert => false } }
+      it { is_expected.to contain_file('authnz_mellon.conf').with_content(/^MELLONVerifyServerCert Off$/) }
+    end
+
+    context 'verifyServerCert = wrong' do
+      let(:params) { { :verifyServerCert => 'wrong' } }
+      it 'should raise an error' do
+        expect { is_expected.to raise_error Puppet::Error }
+      end
+    end
+  end #Debian
+
+  context "on a RedHat OS" do
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '6',
+        :concat_basedir         => '/dne',
+        :id                     => 'root',
+        :kernel                 => 'Linux',
+        :operatingsystem        => 'RedHat',
+        :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      }
+    end
+    it { is_expected.to contain_class("apache::params") }
+    it { is_expected.to contain_class("apache::mod::mellon") }
+    it { is_expected.to contain_apache__mod('authnz_mellon') }
+
+    context 'default verifyServerCert' do
+      it { is_expected.to contain_file('authnz_mellon.conf').with_content(/^MELLONVerifyServerCert On$/) }
+    end
+
+    context 'verifyServerCert = false' do
+      let(:params) { { :verifyServerCert => false } }
+      it { is_expected.to contain_file('authnz_mellon.conf').with_content(/^MELLONVerifyServerCert Off$/) }
+    end
+
+    context 'verifyServerCert = wrong' do
+      let(:params) { { :verifyServerCert => 'wrong' } }
+      it 'should raise an error' do
+        expect { is_expected.to raise_error Puppet::Error }
+      end
+    end
+  end # Redhat
+
+end
+

--- a/templates/mod/authnz_mellon.conf.erb
+++ b/templates/mod/authnz_mellon.conf.erb
@@ -1,0 +1,5 @@
+# This is a placeholder for authnz_mellon global configuration
+# For information on which variables are valid here, see:
+# https://github.com/UNINETT/mod_auth_mellon
+
+


### PR DESCRIPTION
Short and simple: this adds very basic [mod_auth_mellon](https://github.com/UNINETT/mod_auth_mellon) support to puppetlabs-apache. Read the documentation from their project for more details on how this should work.
