### PR TITLE
Fix spec file (remove copypasta)

### DIFF
--- a/spec/classes/mod/authnz_mellon_spec.rb
+++ b/spec/classes/mod/authnz_mellon_spec.rb
@@ -21,22 +21,8 @@ describe 'apache::mod::authnz_mellon', :type => :class do
     it { is_expected.to contain_class("apache::params") }
     it { is_expected.to contain_class("apache::mod::mellon") }
     it { is_expected.to contain_apache__mod('authnz_mellon') }
+    it { is_expected.to contain_file('authnz_mellon.conf') }
 
-    context 'default verifyServerCert' do
-      it { is_expected.to contain_file('authnz_mellon.conf').with_content(/^MELLONVerifyServerCert On$/) }
-    end
-
-    context 'verifyServerCert = false' do
-      let(:params) { { :verifyServerCert => false } }
-      it { is_expected.to contain_file('authnz_mellon.conf').with_content(/^MELLONVerifyServerCert Off$/) }
-    end
-
-    context 'verifyServerCert = wrong' do
-      let(:params) { { :verifyServerCert => 'wrong' } }
-      it 'should raise an error' do
-        expect { is_expected.to raise_error Puppet::Error }
-      end
-    end
   end #Debian
 
   context "on a RedHat OS" do
@@ -54,22 +40,8 @@ describe 'apache::mod::authnz_mellon', :type => :class do
     it { is_expected.to contain_class("apache::params") }
     it { is_expected.to contain_class("apache::mod::mellon") }
     it { is_expected.to contain_apache__mod('authnz_mellon') }
+    it { is_expected.to contain_file('authnz_mellon.conf') }
 
-    context 'default verifyServerCert' do
-      it { is_expected.to contain_file('authnz_mellon.conf').with_content(/^MELLONVerifyServerCert On$/) }
-    end
-
-    context 'verifyServerCert = false' do
-      let(:params) { { :verifyServerCert => false } }
-      it { is_expected.to contain_file('authnz_mellon.conf').with_content(/^MELLONVerifyServerCert Off$/) }
-    end
-
-    context 'verifyServerCert = wrong' do
-      let(:params) { { :verifyServerCert => 'wrong' } }
-      it 'should raise an error' do
-        expect { is_expected.to raise_error Puppet::Error }
-      end
-    end
   end # Redhat
 
 end


### PR DESCRIPTION
This spec file includes a placeholder config file that presently contains no meaningful content. We want it to be present, but its contents are not to be tested (nor are they dependent on variables just yet).

This fixes things.
