### PR TITLE
Remove improper include of apache::mod::mellon

### DIFF
--- a/manifests/mod/authnz_mellon.pp
+++ b/manifests/mod/authnz_mellon.pp
@@ -1,7 +1,6 @@
 class apache::mod::authnz_mellon (
   $verifyServerCert = true,
 ) {
-  include '::apache::mod::mellon'
   ::apache::mod { 'authnz_mellon': }
 
   validate_bool($verifyServerCert)


### PR DESCRIPTION
Straightforward: I improperly included a line copied from ::mod::ldap that doesn't include properly from authnz_mellon. This fixes it.
