### PR TITLE
Rename authnz_mellon to auth_mellon for consistency with Apache module name

### DIFF
--- a/manifests/mod/auth_mellon.pp
+++ b/manifests/mod/auth_mellon.pp
@@ -1,16 +1,16 @@
-class apache::mod::authnz_mellon (
+class apache::mod::auth_mellon (
   $verifyServerCert = true,
 ) {
-  ::apache::mod { 'authnz_mellon': }
+  ::apache::mod { 'auth_mellon': }
 
   validate_bool($verifyServerCert)
 
   # Template uses:
   # - $verifyServerCert
-  file { 'authnz_mellon.conf':
+  file { 'auth_mellon.conf':
     ensure  => file,
-    path    => "${::apache::mod_dir}/authnz_mellon.conf",
-    content => template('apache/mod/authnz_mellon.conf.erb'),
+    path    => "${::apache::mod_dir}/auth_mellon.conf",
+    content => template('apache/mod/auth_mellon.conf.erb'),
     require => Exec["mkdir ${::apache::mod_dir}"],
     before  => File[$::apache::mod_dir],
     notify  => Service['httpd'],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -72,7 +72,7 @@ class apache::params inherits ::apache::version {
         '7'     => 'mod_ldap',
         default => 'mod_authz_ldap',
        },
-      'authnz_mellon' => 'mod_auth_mellon',
+      'auth_mellon' => 'mod_auth_mellon',
       'fastcgi'       => 'mod_fastcgi',
       'fcgid'         => 'mod_fcgid',
       'pagespeed'     => 'mod-pagespeed-stable',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -72,7 +72,7 @@ class apache::params inherits ::apache::version {
         '7'     => 'mod_ldap',
         default => 'mod_authz_ldap',
        },
-      'auth_mellon' => 'mod_auth_mellon',
+      'auth_mellon'   => 'mod_auth_mellon',
       'fastcgi'       => 'mod_fastcgi',
       'fcgid'         => 'mod_fcgid',
       'pagespeed'     => 'mod-pagespeed-stable',

--- a/spec/classes/mod/auth_mellon_spec.rb
+++ b/spec/classes/mod/auth_mellon_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'apache::mod::authnz_mellon', :type => :class do
+describe 'apache::mod::auth_mellon', :type => :class do
   let :pre_condition do
     'include apache'
   end
@@ -20,8 +20,8 @@ describe 'apache::mod::authnz_mellon', :type => :class do
     end
     it { is_expected.to contain_class("apache::params") }
     it { is_expected.to contain_class("apache::mod::mellon") }
-    it { is_expected.to contain_apache__mod('authnz_mellon') }
-    it { is_expected.to contain_file('authnz_mellon.conf') }
+    it { is_expected.to contain_apache__mod('auth_mellon') }
+    it { is_expected.to contain_file('auth_mellon.conf') }
 
   end #Debian
 
@@ -39,8 +39,8 @@ describe 'apache::mod::authnz_mellon', :type => :class do
     end
     it { is_expected.to contain_class("apache::params") }
     it { is_expected.to contain_class("apache::mod::mellon") }
-    it { is_expected.to contain_apache__mod('authnz_mellon') }
-    it { is_expected.to contain_file('authnz_mellon.conf') }
+    it { is_expected.to contain_apache__mod('auth_mellon') }
+    it { is_expected.to contain_file('auth_mellon.conf') }
 
   end # Redhat
 

--- a/templates/mod/auth_mellon.conf.erb
+++ b/templates/mod/auth_mellon.conf.erb
@@ -1,4 +1,4 @@
-# This is a placeholder for authnz_mellon global configuration
+# This is a placeholder for auth_mellon global configuration
 # For information on which variables are valid here, see:
 # https://github.com/UNINETT/mod_auth_mellon
 


### PR DESCRIPTION
I had dubiously named this package authnz_mellon, following the naming convention of authnz_ldap. This fixes it, bringing the name into consistency with the module name.
